### PR TITLE
fix(package): add index.js to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "GENTILHOMME Thomas <gentilhomme.thomas@gmail.com>",
   "files": [
     "index.d.ts",
+    "index.js",
     "languages",
     "src"
   ],


### PR DESCRIPTION
The `index.js` was absent after installing the module.