### PR TITLE
Add Sonatype vulnerability detection strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ await definition.hydratePayloadDependencies(new Map());
 
 The default strategy is **NONE** which mean no strategy at all (we execute nothing).
 
-[NPM Audit](./docs/npm_audit.md) | [Node.js Security WG - Database](./docs/node_security_wg.md) | [**COMING SOON**] Snyk 
-:-------------------------:|:-------------------------:|:-------------------------:
-<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Npm-logo.svg/1200px-Npm-logo.svg.png" width="300"> | <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Node.js_logo.svg/1280px-Node.js_logo.svg.png" width="300"> | <img src="https://res.cloudinary.com/snyk/image/upload/v1537345894/press-kit/brand/logo-black.png" width="400"> 
+[NPM Audit](./docs/npm_audit.md) | [Node.js Security WG - Database](./docs/node_security_wg.md) | [Sonatype - OSS Index](./docs/sonatype.md) | [**COMING SOON**] Snyk 
+:-------------------------:|:-------------------------:|:-------------------------:|:-------------------------:
+<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Npm-logo.svg/1200px-Npm-logo.svg.png" width="300"> | <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Node.js_logo.svg/1280px-Node.js_logo.svg.png" width="300"> | <img src="https://ossindex.sonatype.org/assets/images/sonatype-image.png" width="400"> | <img src="https://res.cloudinary.com/snyk/image/upload/v1537345894/press-kit/brand/logo-black.png" width="400"> 
 
 Those strategies are described as "string" **type** with the following TypeScript definition:
 ```ts
-type Kind = "npm" | "node" | "snyk" | "none";
+type Kind = "npm" | "node" | "sonatype" | "snyk" | "none";
 ```
 
 To add a strategy or better understand how the code works, please consult [the following guide](./docs/adding_new_strategy.md).
@@ -61,6 +61,7 @@ function getStrategy(): Promise<Strategy.Definition>;
 const strategies: {
   SECURITY_WG: "node";
   NPM_AUDIT: "npm";
+  SONATYPE: "sonatype";
   SNYK: "snyk";
   NONE: "none";
 };

--- a/docs/sonatype.md
+++ b/docs/sonatype.md
@@ -1,0 +1,17 @@
+# Sonatype strategy
+[Sonatype OSS Index](https://ossindex.sonatype.org/) is a free catalogue of open source components and scanning tools to help developers identify vulnerabilities, understand risk, and keep their software safe.
+
+This strategy doesn't require the synchronization of a local database, all 
+vulnerabilities are retrieved on the fly. We use the REST API linked to the open 
+source database of the Sonatype OSS Index to hydrate NodeSecure dependencies payloads. 
+The database for **npm** is accessible [here](https://ossindex.sonatype.org/browse/npm?page=0)
+
+```js
+import * as vuln from "@nodesecure/vuln";
+
+const dependencies = new Map();
+// ...retrieve all dependencies using shrinkwraps
+
+const definition = await vuln.setStrategy(vuln.strategies.SONATYPE);
+await definition.hydratePayloadDependencies(dependencies);
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ import { setStrategy, getStrategy, strategies, defaultStrategyName } from "./typ
 import NpmStrategy from "./types/npm-strategy";
 import NodeStrategy from "./types/node-strategy";
 import SnykStrategy from "./types/snyk-strategy";
+import SonatypeStrategy from "./types/sonatype-strategy";
 import Strategy from "./types/strategy";
 
 export {
@@ -20,5 +21,6 @@ export {
   NodeStrategy,
   NpmStrategy,
   SnykStrategy,
+  SonatypeStrategy,
   Strategy
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ export const VULN_MODE = Object.freeze({
   SECURITY_WG: "node",
   NPM_AUDIT: "npm",
   SNYK: "snyk",
+  SONATYPE: "sonatype",
   NONE: "none"
 });
 export const DEFAULT_VULN_MODE = VULN_MODE.NONE;

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -2,12 +2,13 @@
 import { NPMAuditStrategy } from "./npm-audit.js";
 import { SecurityWGStrategy } from "./security-wg.js";
 import { SnykStrategy } from "./snyk.js";
+import { SonatypeStrategy } from "./sonatype.js";
 import { NoneStrategy } from "./none.js";
 
 // CONSTANTS
 import { VULN_MODE } from "../constants.js";
 
-export { NPMAuditStrategy, SecurityWGStrategy, SnykStrategy };
+export { NPMAuditStrategy, SecurityWGStrategy, SnykStrategy, SonatypeStrategy };
 
 export async function initStrategy(strategy, options) {
   switch (strategy) {
@@ -19,6 +20,9 @@ export async function initStrategy(strategy, options) {
 
     case VULN_MODE.SNYK:
       return Object.seal(SnykStrategy());
+
+    case VULN_MODE.SONATYPE:
+      return Object.seal(SonatypeStrategy());
   }
 
   return Object.seal(NoneStrategy());

--- a/src/strategies/none.js
+++ b/src/strategies/none.js
@@ -8,6 +8,6 @@ export function NoneStrategy() {
   };
 }
 
-export async function hydratePayloadDependencies(dependencies) {
+async function hydratePayloadDependencies(dependencies) {
   // Do nothing
 }

--- a/src/strategies/npm-audit.js
+++ b/src/strategies/npm-audit.js
@@ -14,8 +14,9 @@ export function NPMAuditStrategy() {
 }
 
 async function hydratePayloadDependencies(dependencies, options = {}) {
-  const { path } = options;
+  const { path, useStandardFormat } = options;
 
+  const formatVulnerabilities = standardizeVulnsPayload(useStandardFormat);
   const registry = getLocalRegistryURL();
   const arborist = new Arborist({ ...NPM_TOKEN, registry, path });
 
@@ -29,9 +30,10 @@ async function hydratePayloadDependencies(dependencies, options = {}) {
 
       const dependenciesVulnerabilities = dependencies.get(packageName).vulnerabilities;
       dependenciesVulnerabilities.push(
-        ...options.useStandardFormat
-          ? standardizeVulnsPayload(VULN_MODE.NPM_AUDIT, packageVulns.via)
-          : extractPackageVulnsFromSource(packageVulns)
+        ...formatVulnerabilities(
+          VULN_MODE.NPM_AUDIT,
+          [...extractPackageVulnsFromSource(packageVulns)]
+        )
       );
     }
   }

--- a/src/strategies/npm-audit.js
+++ b/src/strategies/npm-audit.js
@@ -13,7 +13,7 @@ export function NPMAuditStrategy() {
   };
 }
 
-export async function hydratePayloadDependencies(dependencies, options = {}) {
+async function hydratePayloadDependencies(dependencies, options = {}) {
   const { path } = options;
 
   const registry = getLocalRegistryURL();
@@ -38,7 +38,7 @@ export async function hydratePayloadDependencies(dependencies, options = {}) {
   catch { }
 }
 
-export function* extractPackageVulnsFromSource(packageVulnerabilities) {
+function* extractPackageVulnsFromSource(packageVulnerabilities) {
   for (const vulnSource of packageVulnerabilities.via) {
     const { title, range, id, name, source, url, dependency, severity, version, vulnerableVersions } = vulnSource;
 

--- a/src/strategies/security-wg.js
+++ b/src/strategies/security-wg.js
@@ -12,7 +12,7 @@ import { VULN_MODE, VULN_FILE_PATH, CACHE_DELAY } from "../constants.js";
 import * as cache from "../cache.js";
 import { standardizeVulnsPayload } from "./vuln-payload/standardize.js";
 
-export async function SecurityWGStrategy(options) {
+export async function SecurityWGStrategy(options = {}) {
   const { hydrateDatabase: udpDb = false } = options;
   if (udpDb) {
     try {
@@ -29,7 +29,7 @@ export async function SecurityWGStrategy(options) {
   };
 }
 
-export async function checkHydrateDB() {
+async function checkHydrateDB() {
   const localCache = cache.load();
   const ts = Math.abs(Date.now() - localCache.lastUpdated);
 
@@ -40,7 +40,7 @@ export async function checkHydrateDB() {
   }
 }
 
-export async function hydratePayloadDependencies(dependencies, options = {}) {
+async function hydratePayloadDependencies(dependencies, options = {}) {
   try {
     const vulnerabilities = await readJsonFile(VULN_FILE_PATH);
     if (vulnerabilities === null) {
@@ -72,7 +72,7 @@ export async function hydratePayloadDependencies(dependencies, options = {}) {
   catch { }
 }
 
-export async function hydrateDatabase() {
+async function hydrateDatabase() {
   const location = await download("nodejs.security-wg", { extract: true, branch: "main" });
   const vulnPath = path.join(location, "vuln", "npm");
 
@@ -104,7 +104,7 @@ export async function hydrateDatabase() {
   }
 }
 
-export function deleteDatabase() {
+function deleteDatabase() {
   try {
     unlinkSync(VULN_FILE_PATH);
   }

--- a/src/strategies/security-wg.js
+++ b/src/strategies/security-wg.js
@@ -47,6 +47,7 @@ async function hydratePayloadDependencies(dependencies, options = {}) {
       return;
     }
 
+    const formatVulnerabilities = standardizeVulnsPayload(options.useStandardFormat);
     const uniqueDependenciesName = new Set([...dependencies.keys()]);
     const filtered = new Set(
       Object.keys(vulnerabilities).filter((name) => uniqueDependenciesName.has(name))
@@ -63,9 +64,7 @@ async function hydratePayloadDependencies(dependencies, options = {}) {
       }
 
       if (detectedVulnerabilities.length > 0) {
-        dep.vulnerabilities = options.useStandardFormat
-          ? standardizeVulnsPayload(VULN_MODE.SECURITY_WG, detectedVulnerabilities)
-          : detectedVulnerabilities;
+        dep.vulnerabilities = formatVulnerabilities(VULN_MODE.SECURITY_WG, detectedVulnerabilities);
       }
     }
   }

--- a/src/strategies/snyk.js
+++ b/src/strategies/snyk.js
@@ -22,7 +22,7 @@ export function SnykStrategy() {
   };
 }
 
-export async function hydratePayloadDependencies(dependencies, options = {}) {
+async function hydratePayloadDependencies(dependencies, options = {}) {
   try {
     const { targetFile, additionalFile } = await getDependenciesFiles(options.path);
     const { data } = await httpie.post(kSnykApiUrl, getRequestOptions(targetFile, additionalFile));

--- a/src/strategies/snyk.js
+++ b/src/strategies/snyk.js
@@ -64,10 +64,9 @@ function getRequestOptions(targetFile, additionalFile) {
 
   return {
     headers: {
-      "Content-Type": "application/json; charset=utf-8",
       Authorization: kAuthHeader
     },
-    body: JSON.stringify(body)
+    body
   };
 }
 

--- a/src/strategies/sonatype.js
+++ b/src/strategies/sonatype.js
@@ -1,4 +1,12 @@
+// Import Third-Party Dependencies
+import * as httpie from "@myunisoft/httpie";
+
+// Import Internal Dependencies
 import { VULN_MODE } from "../constants.js";
+import { formatVulnerabilities } from "./vuln-payload/standardize.js";
+
+// Constants
+const kSonatypeApiURL = "https://ossindex.sonatype.org/api/v3/component-report";
 
 export function SonatypeStrategy() {
   return {
@@ -7,6 +15,80 @@ export function SonatypeStrategy() {
   };
 }
 
-export async function hydratePayloadDependencies(dependencies) {
-  // Do nothing
+/**
+ * @returns {PackageURL}, following the Package URL spec semantic
+ * see: https://github.com/package-url/purl-spec
+ */
+function toPackageURL(packageName, packageVersion) {
+  return `pkg:npm/${packageName}@${packageVersion}`;
+}
+
+/**
+ * Coordinates are Sonatype's component identifiers, we must build them
+ * using package's name and different package's versions
+ */
+function createPackageURLCoordinates([dependencyName, dependencyPayload]) {
+  const { versions } = dependencyPayload;
+
+  return versions.map((version) => toPackageURL(dependencyName, version));
+}
+
+const kSonatypeApiUrl = "https://ossindex.sonatype.org/api/v3/component-report";
+
+async function fetchDataForPackageURLs(coordinates) {
+  const requestOptions = {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    body: JSON.stringify({ coordinates })
+  };
+
+  try {
+    const { data } = await httpie.post(kSonatypeApiURL, requestOptions);
+
+    return JSON.parse(data);
+  }
+  catch {
+    return [];
+  }
+}
+
+/**
+ * @param {PackageURL} purl, following the Package URL spec semantic
+ * see: https://github.com/package-url/purl-spec
+ */
+function extractNameFromPackageURL(purl) {
+  const [, packageData] = purl.split("npm/");
+  const [packageName] = packageData.split("@");
+
+  return packageName;
+}
+
+/**
+ * Package's name is not part of the vulnerability description returned back
+ * by Sonatype. Given that the package name is required in the NodeSecure
+ * vulnerability standard format,
+ */
+function vulnWithPackageName(packageName) {
+  return function provideNameToVulnPayload(vuln) {
+    return { ...vuln, package: packageName };
+  };
+}
+
+async function hydratePayloadDependencies(dependencies, options = {}) {
+  const packageURLsFromDependencies = Array.from(dependencies)
+    .flatMap(createPackageURLCoordinates);
+
+  const packageURLsData = await fetchDataForPackageURLs(packageURLsFromDependencies);
+
+  for (const { coordinates, vulnerabilities: sonatypeVulns } of packageURLsData) {
+    const packageName = extractNameFromPackageURL(coordinates);
+    const formattedVulnerabilities = formatVulnerabilities(
+      VULN_MODE.SONATYPE,
+      sonatypeVulns.map(vulnWithPackageName(packageName))
+    );
+
+    const { vulnerabilities } = dependencies.get(packageName);
+    vulnerabilities.push(...formattedVulnerabilities);
+  }
 }

--- a/src/strategies/sonatype.js
+++ b/src/strategies/sonatype.js
@@ -16,7 +16,7 @@ export function SonatypeStrategy() {
 }
 
 /**
- * @returns {PackageURL}, following the Package URL spec semantic
+ * @returns {PackageURL} package url, following the Package URL spec semantic
  * see: https://github.com/package-url/purl-spec
  */
 function toPackageURL(packageName, packageVersion) {
@@ -32,8 +32,6 @@ function createPackageURLCoordinates([dependencyName, dependencyPayload]) {
 
   return versions.map((version) => toPackageURL(dependencyName, version));
 }
-
-const kSonatypeApiUrl = "https://ossindex.sonatype.org/api/v3/component-report";
 
 async function fetchDataForPackageURLs(coordinates) {
   const requestOptions = {

--- a/src/strategies/sonatype.js
+++ b/src/strategies/sonatype.js
@@ -36,15 +36,15 @@ function createPackageURLCoordinates([dependencyName, dependencyPayload]) {
 async function fetchDataForPackageURLs(coordinates) {
   const requestOptions = {
     headers: {
-      "Content-Type": "application/json; charset=utf-8"
+      Accept: "application/json"
     },
-    body: JSON.stringify({ coordinates })
+    body: { coordinates }
   };
 
   try {
     const { data } = await httpie.post(kSonatypeApiURL, requestOptions);
 
-    return JSON.parse(data);
+    return data;
   }
   catch {
     return [];
@@ -52,8 +52,11 @@ async function fetchDataForPackageURLs(coordinates) {
 }
 
 /**
- * @param {PackageURL} purl, following the Package URL spec semantic
- * see: https://github.com/package-url/purl-spec
+ * @param {string} purl - A string representing the specific Package URL
+ * semantic.
+ * When targetting npm repositories, the specification is the following:
+ * pkg:npm/<package-name>@<package-version> such as: pkg:npm/foobar@12.3.1
+ * For further reading see: https://github.com/package-url/purl-spec
  */
 function extractNameFromPackageURL(purl) {
   const [, packageData] = purl.split("npm/");
@@ -65,7 +68,8 @@ function extractNameFromPackageURL(purl) {
 /**
  * Package's name is not part of the vulnerability description returned back
  * by Sonatype. Given that the package name is required in the NodeSecure
- * vulnerability standard format,
+ * vulnerability standard format, we must be sure to provide it back after
+ * reaching the API.
  */
 function vulnWithPackageName(packageName) {
   return function provideNameToVulnPayload(vuln) {

--- a/src/strategies/sonatype.js
+++ b/src/strategies/sonatype.js
@@ -3,7 +3,7 @@ import * as httpie from "@myunisoft/httpie";
 
 // Import Internal Dependencies
 import { VULN_MODE } from "../constants.js";
-import { formatVulnerabilities } from "./vuln-payload/standardize.js";
+import { standardizeVulnsPayload } from "./vuln-payload/standardize.js";
 
 // Constants
 const kSonatypeApiURL = "https://ossindex.sonatype.org/api/v3/component-report";
@@ -74,6 +74,7 @@ function vulnWithPackageName(packageName) {
 }
 
 async function hydratePayloadDependencies(dependencies, options = {}) {
+  const formatVulnerabilities = standardizeVulnsPayload(options.useStandardFormat);
   const packageURLsFromDependencies = Array.from(dependencies)
     .flatMap(createPackageURLCoordinates);
 

--- a/src/strategies/sonatype.js
+++ b/src/strategies/sonatype.js
@@ -1,0 +1,12 @@
+import { VULN_MODE } from "../constants.js";
+
+export function SonatypeStrategy() {
+  return {
+    strategy: VULN_MODE.SONATYPE,
+    hydratePayloadDependencies
+  };
+}
+
+export async function hydratePayloadDependencies(dependencies) {
+  // Do nothing
+}

--- a/src/strategies/vuln-payload/mappers.js
+++ b/src/strategies/vuln-payload/mappers.js
@@ -1,71 +1,90 @@
 // Import Internal Dependencies
-import { VULN_MODE } from "../../constants.js"
+import { VULN_MODE } from "../../constants.js";
+
+function fromMaybeStringToArray(value) {
+  return value ? [value] : [];
+}
 
 function mapFromSecurityWG(vuln) {
-    return {
-        id: vuln.id,
-        origin: VULN_MODE.SECURITY_WG,
-        package: vuln.module_name,
-        title: vuln.title,
-        description: vuln.overview,
-        cves: vuln.cves,
-        cvssVector: vuln.cvss_vector,
-        cvssScore: vuln.cvss_score,
-        vulnerableVersions: [],
-        vulnerableRanges: convertStringToArrayWhenDefined(vuln.vulnerable_versions),
-        patchedVersions: vuln.patched_versions,
-    }
+  return {
+    id: vuln.id,
+    origin: VULN_MODE.SECURITY_WG,
+    package: vuln.module_name,
+    title: vuln.title,
+    description: vuln.overview,
+    cves: vuln.cves,
+    cvssVector: vuln.cvss_vector,
+    cvssScore: vuln.cvss_score,
+    vulnerableVersions: [],
+    vulnerableRanges: fromMaybeStringToArray(vuln.vulnerable_versions),
+    patchedVersions: vuln.patched_versions
+  };
 }
 
 function mapFromNPM(vuln) {
-    function standardizeSeverity(severity) {
-        if (severity === "moderate") return "medium";
-        return severity;
+  function standardizeSeverity(severity) {
+    if (severity === "moderate") {
+      return "medium";
     }
 
-    return {
-        id: vuln.id,
-        origin: VULN_MODE.NPM_AUDIT,
-        package: vuln.name,
-        title: vuln.title,
-        url: vuln.url,
-        severity: standardizeSeverity(vuln.severity),
-        vulnerableRanges: convertStringToArrayWhenDefined(vuln.range),
-        vulnerableVersions: convertStringToArrayWhenDefined(vuln.vulnerableVersions)
-    }
+    return severity;
+  }
+
+  return {
+    id: vuln.id,
+    origin: VULN_MODE.NPM_AUDIT,
+    package: vuln.name,
+    title: vuln.title,
+    url: vuln.url,
+    severity: standardizeSeverity(vuln.severity),
+    vulnerableRanges: fromMaybeStringToArray(vuln.range),
+    vulnerableVersions: fromMaybeStringToArray(vuln.vulnerableVersions)
+  };
 }
 
 function mapFromSnyk(vuln) {
-    function concatFunctionsVulnVersion(vulnFunctions) {
-        return vulnFunctions
-            .reduce((ranges, functions) => [...ranges, ...functions.version], []);
-    }
+  function concatVulnerableVersions(vulnFunctions) {
+    return vulnFunctions
+      .reduce((ranges, functions) => [...ranges, ...functions.version], []);
+  }
 
-    return {
-        id: vuln.id,
-        origin: VULN_MODE.SNYK,
-        package: vuln.package,
-        title: vuln.title,
-        url: vuln.url,
-        description: vuln.description,
-        severity: vuln.severity,
-        vulnerableVersions: concatFunctionsVulnVersion(vuln.functions),
-        vulnerableRanges: vuln.semver.vulnerable,
-        cves: vuln.identifiers.CVE,
-        cvssVector: vuln.CVSSv3,
-        cvssScore: vuln.cvssScore,
-        patches: vuln.patches
-    }
+  return {
+    id: vuln.id,
+    origin: VULN_MODE.SNYK,
+    package: vuln.package,
+    title: vuln.title,
+    url: vuln.url,
+    description: vuln.description,
+    severity: vuln.severity,
+    vulnerableVersions: concatVulnerableVersions(vuln.functions),
+    vulnerableRanges: vuln.semver.vulnerable,
+    cves: vuln.identifiers.CVE,
+    cvssVector: vuln.CVSSv3,
+    cvssScore: vuln.cvssScore,
+    patches: vuln.patches
+  };
 }
 
-function convertStringToArrayWhenDefined(value) {
-    if (!value) return [];
-    return [value];
+function mapFromSonatype(vuln, packageName) {
+  return {
+    id: vuln.id,
+    origin: VULN_MODE.SONATYPE,
+    package: "debug",
+    title: vuln.title,
+    url: vuln.reference,
+    description: vuln.description,
+    vulnerableRanges: vuln.versionRanges ?? [],
+    vulnerableVersions: vuln.versionRanges ?? [],
+    cves: fromMaybeStringToArray(vuln.cve),
+    cvssVector: vuln.cvssVector,
+    cvssScore: vuln.cvssScore
+  };
 }
 
 export const VULN_MAPPERS = {
-    [VULN_MODE.NPM_AUDIT]: mapFromNPM,
-    [VULN_MODE.SECURITY_WG]: mapFromSecurityWG,
-    [VULN_MODE.SNYK]: mapFromSnyk
+  [VULN_MODE.NPM_AUDIT]: mapFromNPM,
+  [VULN_MODE.SECURITY_WG]: mapFromSecurityWG,
+  [VULN_MODE.SNYK]: mapFromSnyk,
+  [VULN_MODE.SONATYPE]: mapFromSonatype
 };
 

--- a/src/strategies/vuln-payload/mappers.js
+++ b/src/strategies/vuln-payload/mappers.js
@@ -65,11 +65,11 @@ function mapFromSnyk(vuln) {
   };
 }
 
-function mapFromSonatype(vuln, packageName) {
+function mapFromSonatype(vuln) {
   return {
     id: vuln.id,
     origin: VULN_MODE.SONATYPE,
-    package: "debug",
+    package: vuln.package,
     title: vuln.title,
     url: vuln.reference,
     description: vuln.description,

--- a/src/strategies/vuln-payload/standardize.js
+++ b/src/strategies/vuln-payload/standardize.js
@@ -2,8 +2,16 @@
 import { VULN_MAPPERS } from "./mappers.js";
 
 export function standardizeVulnsPayload(strategy, vulns) {
-    if (!VULN_MAPPERS[strategy]) {
-        return [];
-    }
-    return vulns.map(VULN_MAPPERS[strategy]);
+  if (!VULN_MAPPERS[strategy]) {
+    return [];
+  }
+
+  return vulns.map(VULN_MAPPERS[strategy]);
 }
+
+export function formatVulnerabilities(strategy, vulnerabilities, useStandardFormat) {
+  return useStandardFormat ? standardizeVulnsPayload(
+    strategy, vulnerabilities
+  ) : vulnerabilities;
+}
+

--- a/src/strategies/vuln-payload/standardize.js
+++ b/src/strategies/vuln-payload/standardize.js
@@ -1,7 +1,7 @@
 // Import Internal Dependencies
 import { VULN_MAPPERS } from "./mappers.js";
 
-export function standardizeVulnsPayload(strategy, vulns) {
+function useStrategyVulnerabilityMapper(strategy, vulns) {
   if (!VULN_MAPPERS[strategy]) {
     return [];
   }
@@ -9,9 +9,16 @@ export function standardizeVulnsPayload(strategy, vulns) {
   return vulns.map(VULN_MAPPERS[strategy]);
 }
 
-export function formatVulnerabilities(strategy, vulnerabilities, useStandardFormat) {
-  return useStandardFormat ? standardizeVulnsPayload(
-    strategy, vulnerabilities
-  ) : vulnerabilities;
+export function standardizeVulnsPayload(useStandardFormat) {
+  return function formatVulnerabilities(strategy, vulnerabilities) {
+    if (useStandardFormat) {
+      return useStrategyVulnerabilityMapper(
+        strategy, vulnerabilities
+      );
+    }
+
+    // identity function
+    return vulnerabilities;
+  };
 }
 

--- a/test/fixtures/vuln-payload/payloads.js
+++ b/test/fixtures/vuln-payload/payloads.js
@@ -1,68 +1,94 @@
-import { SNYK_VULNERABILITY, NPM_VULNERABILITY, SECURITYWG_VULNERABILITY } from "./vulns.js"
+import { SNYK_VULNERABILITY, NPM_VULNERABILITY, SECURITYWG_VULNERABILITY, SONATYPE_VULNERABILITY } from "./vulns.js";
 
 export const NPM_VULNS_PAYLOADS = {
-    "inputVulnsPayload": {
-        "vulnerabilities": {
-            "slashify": {
-                "via": [NPM_VULNERABILITY]
-            }
-        }
-    },
-    "outputStandardizedPayload": {
-        "id": undefined,
-        "origin": "npm",
-        "package": NPM_VULNERABILITY.name,
-        "title": NPM_VULNERABILITY.title,
-        "url": NPM_VULNERABILITY.url,
-        "severity": "medium",
-        "vulnerableRanges": [NPM_VULNERABILITY.range],
-        "vulnerableVersions": [NPM_VULNERABILITY.vulnerableVersions]
+  inputVulnsPayload: {
+    vulnerabilities: {
+      slashify: {
+        via: [NPM_VULNERABILITY]
+      }
     }
-}
+  },
+  outputStandardizedPayload: {
+    id: undefined,
+    origin: "npm",
+    package: NPM_VULNERABILITY.name,
+    title: NPM_VULNERABILITY.title,
+    url: NPM_VULNERABILITY.url,
+    severity: "medium",
+    vulnerableRanges: [NPM_VULNERABILITY.range],
+    vulnerableVersions: [NPM_VULNERABILITY.vulnerableVersions]
+  }
+};
 
 export const SNYK_VULNS_PAYLOADS = {
-    "inputVulnsPayload": {
-        "vulnerabilities": [
-            SNYK_VULNERABILITY
-        ],
-    },
-    "outputStandardizedPayload": {
-        "id": SNYK_VULNERABILITY.id,
-        "origin": "snyk",
-        "package": SNYK_VULNERABILITY.package,
-        "title": SNYK_VULNERABILITY.title,
-        "url": SNYK_VULNERABILITY.url,
-        "description": SNYK_VULNERABILITY.description,
-        "severity": SNYK_VULNERABILITY.severity,
-        "vulnerableRanges": SNYK_VULNERABILITY.semver.vulnerable,
-        "vulnerableVersions": [
-            ...SNYK_VULNERABILITY.functions[0].version,
-            ...SNYK_VULNERABILITY.functions[1].version,
-        ],
-        "cves": SNYK_VULNERABILITY.identifiers.CVE,
-        "cvssVector": SNYK_VULNERABILITY.CVSSv3,
-        "cvssScore": SNYK_VULNERABILITY.cvssScore,
-        "patches": SNYK_VULNERABILITY.patches
-    }
-}
+  inputVulnsPayload: {
+    vulnerabilities: [
+      SNYK_VULNERABILITY
+    ]
+  },
+  outputStandardizedPayload: {
+    id: SNYK_VULNERABILITY.id,
+    origin: "snyk",
+    package: SNYK_VULNERABILITY.package,
+    title: SNYK_VULNERABILITY.title,
+    url: SNYK_VULNERABILITY.url,
+    description: SNYK_VULNERABILITY.description,
+    severity: SNYK_VULNERABILITY.severity,
+    vulnerableRanges: SNYK_VULNERABILITY.semver.vulnerable,
+    vulnerableVersions: [
+      ...SNYK_VULNERABILITY.functions[0].version,
+      ...SNYK_VULNERABILITY.functions[1].version
+    ],
+    cves: SNYK_VULNERABILITY.identifiers.CVE,
+    cvssVector: SNYK_VULNERABILITY.CVSSv3,
+    cvssScore: SNYK_VULNERABILITY.cvssScore,
+    patches: SNYK_VULNERABILITY.patches
+  }
+};
 
 export const SECURITYWG_VULNS_PAYLOADS = {
-    "inputVulnsPayload": {
-        "vulnerabilities": [
-            SECURITYWG_VULNERABILITY
-        ],
-    },
-    "outputStandardizedPayload": {
-        "id": SECURITYWG_VULNERABILITY.id,
-        "origin": "node",
-        "package": SECURITYWG_VULNERABILITY.module_name,
-        "title": SECURITYWG_VULNERABILITY.title,
-        "description": SECURITYWG_VULNERABILITY.overview,
-        "vulnerableRanges": [SECURITYWG_VULNERABILITY.vulnerable_versions],
-        "vulnerableVersions": [],
-        "cves": SECURITYWG_VULNERABILITY.cves,
-        "cvssVector": SECURITYWG_VULNERABILITY.cvss_vector,
-        "cvssScore": SECURITYWG_VULNERABILITY.cvss_score,
-        "patchedVersions": SECURITYWG_VULNERABILITY.patched_versions
-    }
-}
+  inputVulnsPayload: {
+    vulnerabilities: [
+      SECURITYWG_VULNERABILITY
+    ]
+  },
+  outputStandardizedPayload: {
+    id: SECURITYWG_VULNERABILITY.id,
+    origin: "node",
+    package: SECURITYWG_VULNERABILITY.module_name,
+    title: SECURITYWG_VULNERABILITY.title,
+    description: SECURITYWG_VULNERABILITY.overview,
+    vulnerableRanges: [SECURITYWG_VULNERABILITY.vulnerable_versions],
+    vulnerableVersions: [],
+    cves: SECURITYWG_VULNERABILITY.cves,
+    cvssVector: SECURITYWG_VULNERABILITY.cvss_vector,
+    cvssScore: SECURITYWG_VULNERABILITY.cvss_score,
+    patchedVersions: SECURITYWG_VULNERABILITY.patched_versions
+  }
+};
+
+export const SONATYPE_VULNS_PAYLOADS = {
+  inputVulnsPayload: {
+    vulnerabilities: [
+      SONATYPE_VULNERABILITY
+    ]
+  },
+  outputStandardizedPayload: {
+    id: SONATYPE_VULNERABILITY.id,
+    origin: "sonatype",
+    /**
+     * Package name is harcoded because the input name is not directly available
+     * from the input vulnerability but from an outer object. Outside of the
+     * context of tests, the package name is provided from a High Order Function
+    */
+    package: "debug",
+    title: SONATYPE_VULNERABILITY.title,
+    url: SONATYPE_VULNERABILITY.reference,
+    description: SONATYPE_VULNERABILITY.description,
+    vulnerableRanges: [],
+    vulnerableVersions: [],
+    cves: [],
+    cvssVector: SONATYPE_VULNERABILITY.cvssVector,
+    cvssScore: SONATYPE_VULNERABILITY.cvssScore
+  }
+};

--- a/test/fixtures/vuln-payload/payloads.js
+++ b/test/fixtures/vuln-payload/payloads.js
@@ -3,7 +3,7 @@ import { SNYK_VULNERABILITY, NPM_VULNERABILITY, SECURITYWG_VULNERABILITY, SONATY
 export const NPM_VULNS_PAYLOADS = {
   inputVulnsPayload: {
     vulnerabilities: {
-      slashify: {
+      "@npmcli/git": {
         via: [NPM_VULNERABILITY]
       }
     }
@@ -16,7 +16,7 @@ export const NPM_VULNS_PAYLOADS = {
     url: NPM_VULNERABILITY.url,
     severity: "medium",
     vulnerableRanges: [NPM_VULNERABILITY.range],
-    vulnerableVersions: [NPM_VULNERABILITY.vulnerableVersions]
+    vulnerableVersions: []
   }
 };
 

--- a/test/fixtures/vuln-payload/vulns.js
+++ b/test/fixtures/vuln-payload/vulns.js
@@ -1,138 +1,153 @@
+/* eslint-disable max-len */
 export const NPM_VULNERABILITY = {
-    "source": 1622,
-    "name": "slashify",
-    "dependency": "slashify",
-    "title": "Open Redirect",
-    "url": "https://npmjs.com/advisories/1622",
-    "severity": "moderate",
-    "range": ">=0.0.0",
-    "vulnerableVersions": "*"
-}
+  source: 1622,
+  name: "slashify",
+  dependency: "slashify",
+  title: "Open Redirect",
+  url: "https://npmjs.com/advisories/1622",
+  severity: "moderate",
+  range: ">=0.0.0",
+  vulnerableVersions: "*"
+};
 
 export const SNYK_VULNERABILITY = {
-    "id": "npm:ms:20151024",
-    "url": "https://snyk.io/vuln/npm:ms:20151024",
-    "title": "Regular Expression Denial of Service (ReDoS)",
-    "type": "vuln",
-    "description": "## Overview\n\n[ms](https://www.npmjs.com/package/ms) is a tiny millisecond conversion utility.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nattack when converting a time period string (i.e. `\"2 days\"`, `\"1h\"`) into a milliseconds integer. A malicious user could pass extremely long strings to `ms()`, causing the server to take a long time to process, subsequently blocking the event loop for that extended period.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `ms` to version 0.7.1 or higher.\n\n\n## References\n\n- [OSS Security advisory](https://www.openwall.com/lists/oss-security/2016/04/20/11)\n\n- [OWASP - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n- [Security Focus](https://www.securityfocus.com/bid/96389)\n",
-    "functions": [
-        {
-            "functionId": {
-                "filePath": "ms.js",
-                "functionName": "parse"
-            },
-            "version": [">0.1.0 <=0.3.0"]
-        },
-        {
-            "functionId": {
-                "filePath": "index.js",
-                "functionName": "parse"
-            },
-            "version": [">0.3.0 <0.7.1"]
-        }
-    ],
-    "from": ["ms@0.7.0"],
-    "package": "ms",
-    "version": "0.7.0",
-    "severity": "medium",
-    "exploitMaturity": "no-known-exploit",
-    "language": "js",
-    "packageManager": "npm",
-    "semver": {
-        "vulnerable": ["<0.5.0, >=0.4.0", "<0.3.8, >=0.3.6"]
+  id: "npm:ms:20151024",
+  url: "https://snyk.io/vuln/npm:ms:20151024",
+  title: "Regular Expression Denial of Service (ReDoS)",
+  type: "vuln",
+  description: "## Overview",
+  functions: [
+    {
+      functionId: {
+        filePath: "ms.js",
+        functionName: "parse"
+      },
+      version: [">0.1.0 <=0.3.0"]
     },
-    "publicationTime": "2015-11-06T02:09:36Z",
-    "disclosureTime": "2015-10-24T20:39:59Z",
-    "isUpgradable": true,
-    "isPatchable": true,
-    "isPinnable": false,
-    "identifiers": {
-        "ALTERNATIVE": ["SNYK-JS-MS-10064"],
-        "CVE": ["CVE-2015-8315"],
-        "CWE": ["CWE-400"],
-        "NSP": [46]
+    {
+      functionId: {
+        filePath: "index.js",
+        functionName: "parse"
+      },
+      version: [">0.3.0 <0.7.1"]
+    }
+  ],
+  from: ["ms@0.7.0"],
+  package: "ms",
+  version: "0.7.0",
+  severity: "medium",
+  exploitMaturity: "no-known-exploit",
+  language: "js",
+  packageManager: "npm",
+  semver: {
+    vulnerable: ["<0.5.0, >=0.4.0", "<0.3.8, >=0.3.6"]
+  },
+  publicationTime: "2015-11-06T02:09:36Z",
+  disclosureTime: "2015-10-24T20:39:59Z",
+  isUpgradable: true,
+  isPatchable: true,
+  isPinnable: false,
+  identifiers: {
+    ALTERNATIVE: ["SNYK-JS-MS-10064"],
+    CVE: ["CVE-2015-8315"],
+    CWE: ["CWE-400"],
+    NSP: [46]
+  },
+  credit: ["Adam Baldwin"],
+  CVSSv3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+  cvssScore: 5.3,
+  patches: [
+    {
+      comments: [],
+      id: "patch:npm:ms:20151024:5",
+      modificationTime: "2019-12-03T11:40:45.777474Z",
+      urls: [
+        "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_5_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk5.patch"
+      ],
+      version: "=0.1.0"
     },
-    "credit": ["Adam Baldwin"],
-    "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-    "cvssScore": 5.3,
-    "patches": [
-        {
-            "comments": [],
-            "id": "patch:npm:ms:20151024:5",
-            "modificationTime": "2019-12-03T11:40:45.777474Z",
-            "urls": [
-                "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_5_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk5.patch"
-            ],
-            "version": "=0.1.0"
-        },
-        {
-            "comments": [],
-            "id": "patch:npm:ms:20151024:4",
-            "modificationTime": "2019-12-03T11:40:45.776329Z",
-            "urls": [
-                "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_4_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk4.patch"
-            ],
-            "version": "=0.2.0"
-        },
-        {
-            "comments": [],
-            "id": "patch:npm:ms:20151024:3",
-            "modificationTime": "2019-12-03T11:40:45.775292Z",
-            "urls": [
-                "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_3_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk3.patch"
-            ],
-            "version": "=0.3.0"
-        },
-        {
-            "comments": [],
-            "id": "patch:npm:ms:20151024:2",
-            "modificationTime": "2019-12-03T11:40:45.774221Z",
-            "urls": [
-                "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch"
-            ],
-            "version": "<0.6.0 >0.3.0"
-        },
-        {
-            "comments": [],
-            "id": "patch:npm:ms:20151024:1",
-            "modificationTime": "2019-12-03T11:40:45.773094Z",
-            "urls": [
-                "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch"
-            ],
-            "version": "<0.7.0 >=0.6.0"
-        },
-        {
-            "comments": [],
-            "id": "patch:npm:ms:20151024:0",
-            "modificationTime": "2019-12-03T11:40:45.772009Z",
-            "urls": [
-                "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_0_0_48701f029417faf65e6f5e0b61a3cebe5436b07b.patch"
-            ],
-            "version": "=0.7.0"
-        }
-    ],
-    "upgradePath": ["ms@0.7.1"]
-}
+    {
+      comments: [],
+      id: "patch:npm:ms:20151024:4",
+      modificationTime: "2019-12-03T11:40:45.776329Z",
+      urls: [
+        "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_4_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk4.patch"
+      ],
+      version: "=0.2.0"
+    },
+    {
+      comments: [],
+      id: "patch:npm:ms:20151024:3",
+      modificationTime: "2019-12-03T11:40:45.775292Z",
+      urls: [
+        "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_3_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk3.patch"
+      ],
+      version: "=0.3.0"
+    },
+    {
+      comments: [],
+      id: "patch:npm:ms:20151024:2",
+      modificationTime: "2019-12-03T11:40:45.774221Z",
+      urls: [
+        "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch"
+      ],
+      version: "<0.6.0 >0.3.0"
+    },
+    {
+      comments: [],
+      id: "patch:npm:ms:20151024:1",
+      modificationTime: "2019-12-03T11:40:45.773094Z",
+      urls: [
+        "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch"
+      ],
+      version: "<0.7.0 >=0.6.0"
+    },
+    {
+      comments: [],
+      id: "patch:npm:ms:20151024:0",
+      modificationTime: "2019-12-03T11:40:45.772009Z",
+      urls: [
+        "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_0_0_48701f029417faf65e6f5e0b61a3cebe5436b07b.patch"
+      ],
+      version: "=0.7.0"
+    }
+  ],
+  upgradePath: ["ms@0.7.1"]
+};
 
 export const SECURITYWG_VULNERABILITY = {
-    "id": 472,
-    "title": "NoSQL injection on express-cart",
-    "overview": "[express-cart] Customer and admin email enumeration through MongoDB injection",
-    "created_at": "2018-08-20",
-    "updated_at": "2018-09-10",
-    "publish_date": "1970-01-01",
-    "author": {
-        "name": "Benoit Côté-Jodoin",
-        "website": "http://bcj.io",
-        "username": "becojo"
-    },
-    "module_name": "express-cart",
-    "cves": [],
-    "vulnerable_versions": "<1.1.8",
-    "patched_versions": ">=1.1.8",
-    "recommendation": "Update express-cart module to version >=1.1.8",
-    "references": ["https://hackerone.com/reports/397445"],
-    "cvss_vector": "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:N",
-    "cvss_score": 8.2,
-    "coordinating_vendor": null
-}
+  id: 472,
+  title: "NoSQL injection on express-cart",
+  overview: "[express-cart] Customer and admin email enumeration through MongoDB injection",
+  created_at: "2018-08-20",
+  updated_at: "2018-09-10",
+  publish_date: "1970-01-01",
+  author: {
+    name: "Benoit Côté-Jodoin",
+    website: "http://bcj.io",
+    username: "becojo"
+  },
+  module_name: "express-cart",
+  cves: [],
+  vulnerable_versions: "<1.1.8",
+  patched_versions: ">=1.1.8",
+  recommendation: "Update express-cart module to version >=1.1.8",
+  references: ["https://hackerone.com/reports/397445"],
+  cvss_vector: "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:N",
+  cvss_score: 8.2,
+  coordinating_vendor: null
+};
+
+export const SONATYPE_VULNERABILITY = {
+  id: "a917ab55-851f-4c8b-ac82-6f988881c329",
+  displayName: "OSSINDEX-6f98-8881-c329",
+  title: "CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+  description: "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.",
+  cvssScore: 7.5,
+  cvssVector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+  cwe: "CWE-400",
+  reference: "https://ossindex.sonatype.org/vulnerability/a917ab55-851f-4c8b-ac82-6f988881c329?component-type=npm&component-name=debug&utm_source=httpie&utm_medium=integration",
+  externalReferences: [
+    "https://www.npmjs.com/advisories/534"
+  ]
+};

--- a/test/fixtures/vuln-payload/vulns.js
+++ b/test/fixtures/vuln-payload/vulns.js
@@ -1,13 +1,15 @@
 /* eslint-disable max-len */
 export const NPM_VULNERABILITY = {
-  source: 1622,
-  name: "slashify",
-  dependency: "slashify",
-  title: "Open Redirect",
-  url: "https://npmjs.com/advisories/1622",
+  title: "Arbitrary Command Injection due to Improper Command Sanitization",
+  name: "@npmcli/git",
+  source: 1005085,
+  url: "https://github.com/advisories/GHSA-hxwm-x553-x359",
+  dependency: "@npmcli/git",
   severity: "moderate",
-  range: ">=0.0.0",
-  vulnerableVersions: "*"
+  version: undefined,
+  vulnerableVersions: undefined,
+  range: "<2.0.8",
+  id: undefined
 };
 
 export const SNYK_VULNERABILITY = {

--- a/test/strategies/node_wg.js
+++ b/test/strategies/node_wg.js
@@ -6,7 +6,7 @@ import test from "tape";
 
 // Import Internal Dependencies
 import { VULN_FILE_PATH, TMP_CACHE, VULN_MODE } from "../../src/constants.js";
-import { hydrateDatabase, hydratePayloadDependencies } from "../../src/strategies/security-wg.js";
+import { SecurityWGStrategy } from "../../src/strategies/security-wg.js";
 import { standardizeVulnsPayload } from "../../src/strategies/vuln-payload/standardize.js";
 
 function cleanupCache() {
@@ -44,6 +44,8 @@ function getSecurityWGExpectedPayload() {
 }
 
 test("node.js strategy: hydratePayloadDependencies", async(tape) => {
+  const { hydrateDatabase, hydratePayloadDependencies } = await SecurityWGStrategy();
+
   cleanupCache();
 
   // Re-download database!
@@ -69,6 +71,7 @@ test("node.js strategy: hydratePayloadDependencies", async(tape) => {
 });
 
 test("node.js strategy: hydratePayloadDependencies using standard format", async(tape) => {
+  const { hydrateDatabase, hydratePayloadDependencies } = await SecurityWGStrategy();
   cleanupCache();
 
   // Re-download database!

--- a/test/strategies/node_wg.js
+++ b/test/strategies/node_wg.js
@@ -78,6 +78,7 @@ test("node.js strategy: hydratePayloadDependencies using standard format", async
   await hydrateDatabase();
 
   try {
+    const formatVulnerabilities = standardizeVulnsPayload(true);
     const dependencies = new Map();
     // see: https://github.com/nodejs/security-wg/blob/main/vuln/npm/100.json
     dependencies.set("uri-js", {
@@ -88,7 +89,7 @@ test("node.js strategy: hydratePayloadDependencies using standard format", async
     await hydratePayloadDependencies(dependencies, { useStandardFormat: true });
 
     const vulns = dependencies.get("uri-js").vulnerabilities;
-    tape.deepEqual(vulns, standardizeVulnsPayload(VULN_MODE.SECURITY_WG, [getSecurityWGExpectedPayload()]));
+    tape.deepEqual(vulns, formatVulnerabilities(VULN_MODE.SECURITY_WG, [getSecurityWGExpectedPayload()]));
   }
   finally {
     cleanupCache();

--- a/test/strategies/none.js
+++ b/test/strategies/none.js
@@ -13,9 +13,10 @@ test("NoneStrategy definition must return only two keys.", (tape) => {
 });
 
 test("none: hydratePayloadDependencies should not hydrate dependencies Map", async(tape) => {
+  const { hydratePayloadDependencies } = none.NoneStrategy();
   const dependencies = new Map();
 
-  await none.hydratePayloadDependencies(dependencies);
+  await hydratePayloadDependencies(dependencies);
   tape.strictEqual(dependencies.size, 0, "dependencies must be always empty with none strategy");
 
   tape.end();

--- a/test/strategies/npm_audit.js
+++ b/test/strategies/npm_audit.js
@@ -13,20 +13,6 @@ import { NPM_VULNS_PAYLOADS } from "../fixtures/vuln-payload/payloads.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const kFixturesDir = path.join(__dirname, "..", "fixtures");
 
-function getNPMAuditExpectedPayload() {
-  return {
-    title: "Arbitrary Command Injection due to Improper Command Sanitization",
-    name: "@npmcli/git",
-    source: 1005085,
-    url: "https://github.com/advisories/GHSA-hxwm-x553-x359",
-    dependency: "@npmcli/git",
-    severity: "moderate",
-    version: undefined,
-    vulnerableVersions: undefined,
-    range: "<2.0.8",
-    id: undefined
-  };
-}
 
 /**
  * @param {test.Test} tape
@@ -55,6 +41,19 @@ test("NPMAuditStrategy definition must return only two keys.", (tape) => {
 test("npm strategy: hydratePayloadDependencies", async(tape) => {
   const { hydratePayloadDependencies } = NPMAuditStrategy();
   const dependencies = new Map();
+  const NPMAuditExpectedPayload = {
+    title: "Arbitrary Command Injection due to Improper Command Sanitization",
+    name: "@npmcli/git",
+    source: 1005085,
+    url: "https://github.com/advisories/GHSA-hxwm-x553-x359",
+    dependency: "@npmcli/git",
+    severity: "moderate",
+    version: undefined,
+    vulnerableVersions: undefined,
+    range: "<2.0.8",
+    id: undefined
+  };
+
   dependencies.set("@npmcli/git", { vulnerabilities: [] });
 
   await hydratePayloadDependencies(dependencies, {
@@ -65,8 +64,10 @@ test("npm strategy: hydratePayloadDependencies", async(tape) => {
   const { vulnerabilities } = dependencies.get("@npmcli/git");
   tape.strictEqual(vulnerabilities.length, 1);
 
-  isAdvisory(tape, vulnerabilities[0]);
-  tape.deepEqual(vulnerabilities[0], getNPMAuditExpectedPayload());
+  const [npmcliVuln] = vulnerabilities;
+
+  isAdvisory(tape, npmcliVuln);
+  tape.deepEqual(npmcliVuln, NPMAuditExpectedPayload);
 
   tape.end();
 });
@@ -85,7 +86,6 @@ test("npm strategy: hydratePayloadDependencies using NodeSecure standard format"
   const { vulnerabilities } = dependencies.get("@npmcli/git");
   tape.strictEqual(vulnerabilities.length, 1);
 
-  tape.notDeepEqual(vulnerabilities[0], getNPMAuditExpectedPayload());
   tape.deepEqual(
     Object.keys(vulnerabilities[0]),
     Object.keys(NPM_VULNS_PAYLOADS.outputStandardizedPayload)

--- a/test/strategies/npm_audit.js
+++ b/test/strategies/npm_audit.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url";
 import test from "tape";
 
 // Import Internal Dependencies
-import { NPMAuditStrategy, hydratePayloadDependencies } from "../../src/strategies/npm-audit.js";
+import { NPMAuditStrategy } from "../../src/strategies/npm-audit.js";
 import { NPM_VULNS_PAYLOADS } from "../fixtures/vuln-payload/payloads.js";
 
 // CONSTANTS
@@ -53,6 +53,7 @@ test("NPMAuditStrategy definition must return only two keys.", (tape) => {
 });
 
 test("npm strategy: hydratePayloadDependencies", async(tape) => {
+  const { hydratePayloadDependencies } = NPMAuditStrategy();
   const dependencies = new Map();
   dependencies.set("@npmcli/git", { vulnerabilities: [] });
 
@@ -71,6 +72,7 @@ test("npm strategy: hydratePayloadDependencies", async(tape) => {
 });
 
 test("npm strategy: hydratePayloadDependencies using NodeSecure standard format", async(tape) => {
+  const { hydratePayloadDependencies } = NPMAuditStrategy();
   const dependencies = new Map();
   dependencies.set("@npmcli/git", { vulnerabilities: [] });
 

--- a/test/strategies/snyk.js
+++ b/test/strategies/snyk.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url";
 import test from "tape";
 
 // Import Internal Dependencies
-import { SnykStrategy, hydratePayloadDependencies } from "../../src/strategies/snyk.js";
+import { SnykStrategy } from "../../src/strategies/snyk.js";
 import { readJsonFile } from "../../src/utils.js";
 import { standardizeVulnsPayload } from "../../src/strategies/vuln-payload/standardize.js";
 

--- a/test/strategies/sonatype.js
+++ b/test/strategies/sonatype.js
@@ -1,0 +1,58 @@
+// Import Third-party Dependencies
+import test from "tape";
+
+// Import Internal Dependencies
+import { SonatypeStrategy } from "../../src/strategies/sonatype.js";
+import { SONATYPE_VULNS_PAYLOADS } from "../fixtures/vuln-payload/payloads.js";
+
+// CONSTANTS
+
+test("SonatypeStrategy definition must return only two keys.", (tape) => {
+  const definition = SonatypeStrategy();
+
+  tape.strictEqual(definition.strategy, "sonatype", "strategy property must equal 'sonatype'");
+  tape.deepEqual(Object.keys(definition).sort(), ["strategy", "hydratePayloadDependencies"].sort());
+
+  tape.end();
+});
+
+test("sonatype strategy: hydratePayloadDependencies using NodeSecure standard format", async(tape) => {
+  const { hydratePayloadDependencies } = SonatypeStrategy();
+  const dependencies = new Map();
+
+  dependencies.set("debug", {
+    vulnerabilities: [],
+    versions: ["3.0.1"]
+  });
+
+  await hydratePayloadDependencies(dependencies, {
+  });
+
+  tape.strictEqual(dependencies.size, 1, "hydratePayloadDependencies must not add new dependencies by itself");
+  const { vulnerabilities } = dependencies.get("debug");
+  tape.strictEqual(vulnerabilities.length, 1);
+
+  tape.end();
+});
+
+test("sonatype strategy: hydratePayloadDependencies using NodeSecure standard format", async(tape) => {
+  const { hydratePayloadDependencies } = SonatypeStrategy();
+  const dependencies = new Map();
+
+  dependencies.set("debug", {
+    vulnerabilities: [],
+    versions: ["3.0.1"]
+  });
+
+  await hydratePayloadDependencies(dependencies, { useStandardFormat: true });
+
+  tape.strictEqual(dependencies.size, 1, "hydratePayloadDependencies must not add new dependencies by itself");
+  const { vulnerabilities } = dependencies.get("debug");
+  tape.strictEqual(vulnerabilities.length, 1);
+
+  const [standardizedVulnFromSonatype] = vulnerabilities;
+
+  tape.deepEqual(standardizedVulnFromSonatype, SONATYPE_VULNS_PAYLOADS.outputStandardizedPayload);
+
+  tape.end();
+});

--- a/test/strategies/vuln-payload/standardize.js
+++ b/test/strategies/vuln-payload/standardize.js
@@ -8,17 +8,19 @@ import {
   SONATYPE_VULNS_PAYLOADS
 } from "../../fixtures/vuln-payload/payloads.js";
 
+const formatVulnerabilities = standardizeVulnsPayload(true);
+
 test("should convert NONE or unknown strategy into blank payload", (tape) => {
-  let notStandardized = standardizeVulnsPayload(VULN_MODE.NONE, [{}, {}]);
+  let notStandardized = formatVulnerabilities(VULN_MODE.NONE, [{}, {}]);
   tape.isEquivalent(notStandardized, []);
-  notStandardized = standardizeVulnsPayload("exploit", {});
+  notStandardized = formatVulnerabilities("exploit", {});
   tape.isEquivalent(notStandardized, []);
   tape.end();
 });
 
 test("should convert NPM strategy vulns payload into NodeSecure standard payload", (tape) => {
   const { vulnerabilities } = NPM_VULNS_PAYLOADS.inputVulnsPayload;
-  const [fromNPMToStandardFormat] = standardizeVulnsPayload(
+  const [fromNPMToStandardFormat] = formatVulnerabilities(
     VULN_MODE.NPM_AUDIT, vulnerabilities.slashify.via
   );
   tape.deepEqual(fromNPMToStandardFormat, NPM_VULNS_PAYLOADS.outputStandardizedPayload);
@@ -26,7 +28,7 @@ test("should convert NPM strategy vulns payload into NodeSecure standard payload
 });
 
 test("should convert Snyk strategy payload into NodeSecure standard payload", (tape) => {
-  const [fromSnykToStandardFormat] = standardizeVulnsPayload(
+  const [fromSnykToStandardFormat] = formatVulnerabilities(
     VULN_MODE.SNYK, SNYK_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
   );
   tape.deepEqual(fromSnykToStandardFormat, SNYK_VULNS_PAYLOADS.outputStandardizedPayload);
@@ -34,7 +36,7 @@ test("should convert Snyk strategy payload into NodeSecure standard payload", (t
 });
 
 test("should convert NodeWG strategy payload into NodeSecure standard payload", (tape) => {
-  const [nodeWGToStandardFormat] = standardizeVulnsPayload(
+  const [nodeWGToStandardFormat] = formatVulnerabilities(
     VULN_MODE.SECURITY_WG, SECURITYWG_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
   );
   tape.deepEqual(nodeWGToStandardFormat, SECURITYWG_VULNS_PAYLOADS.outputStandardizedPayload);
@@ -42,9 +44,18 @@ test("should convert NodeWG strategy payload into NodeSecure standard payload", 
 });
 
 test("should convert Sonatype strategy payload into NodeSecure standard payload", (tape) => {
-  const [sonatypeToStandardFormat] = standardizeVulnsPayload(
+  const [sonatypeToStandardFormat] = formatVulnerabilities(
     VULN_MODE.SONATYPE, SONATYPE_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
   );
-  tape.deepEqual(sonatypeToStandardFormat, SONATYPE_VULNS_PAYLOADS.outputStandardizedPayload);
+  /**
+   * Package's name is not part of the vuln payload. It is provided from another
+   * part of the sonatype payload. To avoid any confusion, it is spreaded here
+   * in addition to the vuln payload.
+  */
+  const packageName = "debug";
+  tape.deepEqual(
+    { ...sonatypeToStandardFormat, package: packageName },
+    SONATYPE_VULNS_PAYLOADS.outputStandardizedPayload
+  );
   tape.end();
 });

--- a/test/strategies/vuln-payload/standardize.js
+++ b/test/strategies/vuln-payload/standardize.js
@@ -1,37 +1,50 @@
 import test from "tape";
 import { VULN_MODE } from "../../../src/constants.js";
 import { standardizeVulnsPayload } from "../../../src/strategies/vuln-payload/standardize.js";
-import { NPM_VULNS_PAYLOADS, SECURITYWG_VULNS_PAYLOADS, SNYK_VULNS_PAYLOADS } from "../../fixtures/vuln-payload/payloads.js";
+import {
+  NPM_VULNS_PAYLOADS,
+  SECURITYWG_VULNS_PAYLOADS,
+  SNYK_VULNS_PAYLOADS,
+  SONATYPE_VULNS_PAYLOADS
+} from "../../fixtures/vuln-payload/payloads.js";
 
 test("should convert NONE or unknown strategy into blank payload", (tape) => {
-    let notStandardized = standardizeVulnsPayload(VULN_MODE.NONE, [{}, {}]);
-    tape.isEquivalent(notStandardized, []);
-    notStandardized = standardizeVulnsPayload("exploit", {});
-    tape.isEquivalent(notStandardized, []);
-    tape.end();
+  let notStandardized = standardizeVulnsPayload(VULN_MODE.NONE, [{}, {}]);
+  tape.isEquivalent(notStandardized, []);
+  notStandardized = standardizeVulnsPayload("exploit", {});
+  tape.isEquivalent(notStandardized, []);
+  tape.end();
 });
 
 test("should convert NPM strategy vulns payload into NodeSecure standard payload", (tape) => {
-    const { vulnerabilities } = NPM_VULNS_PAYLOADS.inputVulnsPayload;
-    const [fromNPMToStandardFormat] = standardizeVulnsPayload(
-        VULN_MODE.NPM_AUDIT, vulnerabilities.slashify.via
-    );
-    tape.deepEqual(fromNPMToStandardFormat, NPM_VULNS_PAYLOADS.outputStandardizedPayload);
-    tape.end();
+  const { vulnerabilities } = NPM_VULNS_PAYLOADS.inputVulnsPayload;
+  const [fromNPMToStandardFormat] = standardizeVulnsPayload(
+    VULN_MODE.NPM_AUDIT, vulnerabilities.slashify.via
+  );
+  tape.deepEqual(fromNPMToStandardFormat, NPM_VULNS_PAYLOADS.outputStandardizedPayload);
+  tape.end();
 });
 
 test("should convert Snyk strategy payload into NodeSecure standard payload", (tape) => {
-    const [fromSnykToStandardFormat] = standardizeVulnsPayload(
-        VULN_MODE.SNYK, SNYK_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
-    );
-    tape.deepEqual(fromSnykToStandardFormat, SNYK_VULNS_PAYLOADS.outputStandardizedPayload);
-    tape.end();
+  const [fromSnykToStandardFormat] = standardizeVulnsPayload(
+    VULN_MODE.SNYK, SNYK_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
+  );
+  tape.deepEqual(fromSnykToStandardFormat, SNYK_VULNS_PAYLOADS.outputStandardizedPayload);
+  tape.end();
 });
 
 test("should convert NodeWG strategy payload into NodeSecure standard payload", (tape) => {
-    const [nodeWGToStandardFormat] = standardizeVulnsPayload(
-        VULN_MODE.SECURITY_WG, SECURITYWG_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
-    );
-    tape.deepEqual(nodeWGToStandardFormat, SECURITYWG_VULNS_PAYLOADS.outputStandardizedPayload);
-    tape.end();
+  const [nodeWGToStandardFormat] = standardizeVulnsPayload(
+    VULN_MODE.SECURITY_WG, SECURITYWG_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
+  );
+  tape.deepEqual(nodeWGToStandardFormat, SECURITYWG_VULNS_PAYLOADS.outputStandardizedPayload);
+  tape.end();
+});
+
+test("should convert Sonatype strategy payload into NodeSecure standard payload", (tape) => {
+  const [sonatypeToStandardFormat] = standardizeVulnsPayload(
+    VULN_MODE.SONATYPE, SONATYPE_VULNS_PAYLOADS.inputVulnsPayload.vulnerabilities
+  );
+  tape.deepEqual(sonatypeToStandardFormat, SONATYPE_VULNS_PAYLOADS.outputStandardizedPayload);
+  tape.end();
 });

--- a/test/strategies/vuln-payload/standardize.js
+++ b/test/strategies/vuln-payload/standardize.js
@@ -21,7 +21,7 @@ test("should convert NONE or unknown strategy into blank payload", (tape) => {
 test("should convert NPM strategy vulns payload into NodeSecure standard payload", (tape) => {
   const { vulnerabilities } = NPM_VULNS_PAYLOADS.inputVulnsPayload;
   const [fromNPMToStandardFormat] = formatVulnerabilities(
-    VULN_MODE.NPM_AUDIT, vulnerabilities.slashify.via
+    VULN_MODE.NPM_AUDIT, vulnerabilities["@npmcli/git"].via
   );
   tape.deepEqual(fromNPMToStandardFormat, NPM_VULNS_PAYLOADS.outputStandardizedPayload);
   tape.end();

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -13,6 +13,7 @@ declare const strategies: {
   SECURITY_WG: "node";
   NPM_AUDIT: "npm";
   SNYK: "snyk";
+  SONATYPE: "sonatype";
   NONE: "none";
 };
 declare const defaultStrategyName: string;

--- a/types/sonatype-strategy.d.ts
+++ b/types/sonatype-strategy.d.ts
@@ -1,0 +1,17 @@
+export = SonatypeStrategy;
+
+declare namespace SonatypeStrategy {    
+  export interface Vulnerability {
+    id: string;
+    displayName: string;
+    title: string;
+    description: string;
+    cvssScore: number;
+    cvssVector: string;
+    cwe: string;
+    cve?: string;
+    reference: string;
+    externalReferences: string[];
+    versionRanges: string[];
+  }
+}

--- a/types/strategy.d.ts
+++ b/types/strategy.d.ts
@@ -4,7 +4,7 @@ import SnykStrategy from "./snyk-strategy";
 export = Strategy;
 
 declare namespace Strategy {
-  export type Kind = "npm" | "node" | "snyk" | "none";
+  export type Kind = "npm" | "node" | "snyk" | "sonatype" | "none";
 
   // Degraded version from scanner (only implement what we need).
   export interface VersionDescriptor {


### PR DESCRIPTION
Reference issue #19 

In this PR : 
- Sonatype vulnerability strategy is added and plugged with the Sonatype API
- Strategies' functions e.g: `hydratePayloadDependencies` are not exported anymore to be only used through the factory function scope 
- Formatting issues are fixed on several files 

With the growing number of strategies, I'm planning to open a PR which will colocalize each strategy mapper with the strategy definition instead of mixing all different mappers in the same file.